### PR TITLE
integrate mobileclip with hugginggface

### DIFF
--- a/mobileclip/__init__.py
+++ b/mobileclip/__init__.py
@@ -118,7 +118,7 @@ def from_pretrained(
     if reparameterize:
         model = reparameterize_model(model)
 
-    cfg = model._hub_mixin_config["cfg"]
+    cfg = model.cfg
     resolution = cfg["image_cfg"]["image_size"]
     resize_size = resolution
     centercrop_size = resolution

--- a/mobileclip/clip.py
+++ b/mobileclip/clip.py
@@ -29,6 +29,7 @@ class CLIP(
     def __init__(self, cfg: Dict, output_dict: bool = False, *args, **kwargs) -> None:
         super().__init__()
         self.output_dict = output_dict
+        self.cfg = cfg
         self.projection_dim = cfg["embed_dim"]
         if self.projection_dim is None:
             raise ValueError("Please specify `embed_dim` in model config.")
@@ -64,7 +65,7 @@ class CLIP(
         image: Optional[torch.Tensor] = None,
         text: Optional[torch.Tensor] = None,
         *args,
-        **kwargs
+        **kwargs,
     ) -> Any:
         image_embeddings = (
             self.encode_image(image, normalize=True) if image is not None else None

--- a/mobileclip/clip.py
+++ b/mobileclip/clip.py
@@ -18,11 +18,12 @@ from mobileclip.text_encoder import (
 from .image_encoder import MCi
 
 
-class CLIP(nn.Module,
-           PyTorchModelHubMixin,
-           library_name="CLIP",
-           repo_url="https://github.com/apple/ml-mobileclip"
-           ):
+class CLIP(
+    nn.Module,
+    PyTorchModelHubMixin,
+    library_name="CLIP",
+    repo_url="https://github.com/apple/ml-mobileclip",
+):
     """Base class for multi-modal image-text data"""
 
     def __init__(self, cfg: Dict, output_dict: bool = False, *args, **kwargs) -> None:
@@ -65,7 +66,6 @@ class CLIP(nn.Module,
         *args,
         **kwargs
     ) -> Any:
-
         image_embeddings = (
             self.encode_image(image, normalize=True) if image is not None else None
         )

--- a/mobileclip/clip.py
+++ b/mobileclip/clip.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Dict
 import torch
 import torch.nn.functional as F
 from torch import nn
+from huggingface_hub import PyTorchModelHubMixin
 
 from mobileclip.text_encoder import (
     TextTransformer,
@@ -17,7 +18,11 @@ from mobileclip.text_encoder import (
 from .image_encoder import MCi
 
 
-class CLIP(nn.Module):
+class CLIP(nn.Module,
+           PyTorchModelHubMixin,
+           library_name="CLIP",
+           repo_url="https://github.com/apple/ml-mobileclip"
+           ):
     """Base class for multi-modal image-text data"""
 
     def __init__(self, cfg: Dict, output_dict: bool = False, *args, **kwargs) -> None:

--- a/mobileclip/clip.py
+++ b/mobileclip/clip.py
@@ -21,7 +21,7 @@ from .image_encoder import MCi
 class CLIP(
     nn.Module,
     PyTorchModelHubMixin,
-    library_name="CLIP",
+    library_name="mobileclip",
     repo_url="https://github.com/apple/ml-mobileclip",
 ):
     """Base class for multi-modal image-text data"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ open-clip-torch>=2.20.0
 timm>=0.9.5
 torch==1.13.1
 torchvision==0.14.1
+huggingface_hub>=0.22


### PR DESCRIPTION
This pr is about allowing for huggingface integration, I made this [notebook](https://colab.research.google.com/drive/1y_QeQCjP7BZP9vOW1GJTOA1rTeW7Oq5_?usp=sharing) using `PytorchModelHubMixin` allowing us to download, load and initialize the model in 1 line 
```python
from mobileclip import CLIP
NewModel = CLIP.from_pretrained("not-lain/mobileclip_s0")
```

I also added a simplified method for loading all the dependencies using the following code 
```python
import mobileclip
model, tokenizer , preprocess = mobileclip.from_pretrained("not-lain/mobileclip_s0") 
```

Apart from adding `push_to_hub`, `from_pretrained`, `save_pretrained` to any pytorch model, the [`PytorchModelHubMixin`](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) allows for huggingface integration meaning you get to :
* Keep track on how many times your model has been downloaded by the community.
* Automatic model card generation:  the metadata in the card allows you to filter your [searches](https://huggingface.co/models?other=mobileclip) easily to check how many mobileclip models exist on the Hub .
* Recommended: after this pr is merged we can open a pull request [on this file](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) to make the "mobileclip" library official on the Hub meaning better discoverability + possibility to add code snippets.

Do not hesitate if you have any reviews on the pr or any questions.


Kind regards,
* Hafedh Hichri